### PR TITLE
fix-standard-sql-regex

### DIFF
--- a/src/bigquery_view_analyzer/analyzer.py
+++ b/src/bigquery_view_analyzer/analyzer.py
@@ -7,7 +7,7 @@ from colorama import Fore, init
 from google.cloud import bigquery
 from google.cloud.bigquery import Table, AccessEntry, Dataset
 
-STANDARD_SQL_TABLE_PATTERN = r"(?:(?:FROM|JOIN)\s+?)?`(?P<project>[-\w]+?)`?\.`?(?P<dataset>[-\w]+?)`?\.`?(?P<table>[-\w]+)`?"
+STANDARD_SQL_TABLE_PATTERN = r"(?:(?:FROM|JOIN)\s+?)?`(?P<project>[-\w]+?)`?\.`?(?P<dataset>[\w]+?)`?\.`?(?P<table>[\w]+)`?"
 LEGACY_SQL_TABLE_PATTERN = r"(?:(?:FROM|JOIN)\s+?)?\[(?:(?P<project>[-\w]+?)(?:\:))?(?P<dataset>[-\w]+?)\.(?P<table>[-\w]+?)\]"
 
 logging.basicConfig()

--- a/src/bigquery_view_analyzer/analyzer.py
+++ b/src/bigquery_view_analyzer/analyzer.py
@@ -7,7 +7,7 @@ from colorama import Fore, init
 from google.cloud import bigquery
 from google.cloud.bigquery import Table, AccessEntry, Dataset
 
-STANDARD_SQL_TABLE_PATTERN = r"(?:(?:FROM|JOIN)\s+?)?`?(?P<project>[-\w]+?)`?\.`?(?P<dataset>[-\w]+?)`?\.`?(?P<table>[-\w]+)`?"
+STANDARD_SQL_TABLE_PATTERN = r"(?:(?:FROM|JOIN)\s+?)?`(?P<project>[-\w]+?)`?\.`?(?P<dataset>[-\w]+?)`?\.`?(?P<table>[-\w]+)`?"
 LEGACY_SQL_TABLE_PATTERN = r"(?:(?:FROM|JOIN)\s+?)?\[(?:(?P<project>[-\w]+?)(?:\:))?(?P<dataset>[-\w]+?)\.(?P<table>[-\w]+?)\]"
 
 logging.basicConfig()

--- a/tests/test_view_analyzer.py
+++ b/tests/test_view_analyzer.py
@@ -18,7 +18,7 @@ standard_table_references = [
     "project.dataset.table",
 ]
 legacy_table_references = ["[project:dataset.table]", "[dataset.table]"]
-join_prefix = ["LEFT", "RIGHT", "CROSS", "FULL OUTER"]
+join_prefix = ["INNER", "LEFT", "RIGHT", "CROSS", "FULL OUTER"]
 
 
 @pytest.mark.parametrize("table_a", standard_table_references)

--- a/tests/test_view_analyzer.py
+++ b/tests/test_view_analyzer.py
@@ -18,7 +18,7 @@ standard_table_references = [
     "project.dataset.table",
 ]
 legacy_table_references = ["[project:dataset.table]", "[dataset.table]"]
-join_prefix = ["INNER", "LEFT", "RIGHT", "CROSS", "FULL OUTER"]
+join_prefix = ["", "INNER", "LEFT", "RIGHT", "CROSS", "FULL OUTER"]
 
 
 @pytest.mark.parametrize("table_a", standard_table_references)

--- a/tests/test_view_analyzer.py
+++ b/tests/test_view_analyzer.py
@@ -7,24 +7,28 @@ from bigquery_view_analyzer.analyzer import (
 )
 
 
-standard_table_references = [
+valid_standard_table_references = [
     "`project.dataset.table`",
     "`project`.dataset.table",
     "`project.dataset`.table",
+    "`project`.`dataset`.`table`",
+]
+
+invalid_standard_table_references = [
     "project.`dataset`.table",
     "project.`dataset.table`",
     "project.dataset.`table`",
-    "`project`.`dataset`.`table`",
     "project.dataset.table",
 ]
+
 legacy_table_references = ["[project:dataset.table]", "[dataset.table]"]
 join_prefix = ["", "INNER", "LEFT", "RIGHT", "CROSS", "FULL OUTER"]
 
 
-@pytest.mark.parametrize("table_a", standard_table_references)
-@pytest.mark.parametrize("table_b", standard_table_references)
+@pytest.mark.parametrize("table_a", valid_standard_table_references)
+@pytest.mark.parametrize("table_b", valid_standard_table_references)
 @pytest.mark.parametrize("join_prefix", join_prefix)
-def test_standard_table_reference_in_view(table_a, table_b, join_prefix):
+def test_valid_standard_table_reference_in_view(table_a, table_b, join_prefix):
     sql_ddl = """
     SELECT
         table_a.id
@@ -43,6 +47,29 @@ def test_standard_table_reference_in_view(table_a, table_b, join_prefix):
     )
     assert match is not None
     assert len(match) == 2  # find both table a and b
+
+
+@pytest.mark.parametrize("table_a", invalid_standard_table_references)
+@pytest.mark.parametrize("table_b", invalid_standard_table_references)
+@pytest.mark.parametrize("join_prefix", join_prefix)
+def test_invalid_standard_table_reference_in_view(table_a, table_b, join_prefix):
+    sql_ddl = """
+    SELECT
+        table_a.id
+        ,table_a.field_a
+        ,table_b.field_b
+        ,table_b.field_a AS different_field_a
+    FROM
+        {table_a} AS table_a
+    {join_prefix} JOIN
+        {table_b} AS table_b
+    """.format(
+        table_a=table_a, table_b=table_b, join_prefix=join_prefix
+    )
+    match = re.findall(
+        STANDARD_SQL_TABLE_PATTERN, sql_ddl, re.IGNORECASE | re.MULTILINE
+    )
+    assert match == []
 
 
 @pytest.mark.parametrize("table_a", legacy_table_references)


### PR DESCRIPTION
## Summary
Fix issue where a string following the same pattern (ex: 'abcd.efgh.ijkl') is interpreted as table, causing an error.

Issue https://github.com/servian/bigquery-view-analyzer/issues/9


### Standard Sql Regex Changes
- Make the first backtick at beginning of project name required instead of optional
  - Per [BigQuery DDL documentation](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_view_statement):
    >When you use a DDL statement to create a view, you must specify the project, dataset, and view in the following format: \`project_id.dataset.table\` (including the backticks); for example, \`myproject.mydataset.newview\`. 
  - Examples:
    - [Current regex](https://regex101.com/r/E9mK3B/1)
    - [Fixed regex](https://regex101.com/r/E9mK3B/2)

- Remove dash character from dataset & table qualifiers
  - Per [BigQuery Datasets documentation](https://cloud.google.com/bigquery/docs/datasets#dataset-naming):
    >Dataset names cannot: 
    >- Contain spaces or special characters such as -, &, @, or %
  - Per [BigQuery Tables documentation](https://cloud.google.com/bigquery/docs/tables#table_naming)
    >The table name can:
    >- Contain up to 1,024 characters
    >- Contain letters (upper or lower case), numbers, and underscores

### Test Changes
- Add test for invalid table references
- Add empty string (`""`) and `"INNER"` to join prefixes