### PR TITLE
Update standard sql pattern to exclude UDFs

### DIFF
--- a/src/bigquery_view_analyzer/analyzer.py
+++ b/src/bigquery_view_analyzer/analyzer.py
@@ -7,7 +7,7 @@ from colorama import Fore, init
 from google.cloud import bigquery
 from google.cloud.bigquery import Table, AccessEntry, Dataset
 
-STANDARD_SQL_TABLE_PATTERN = r"(?:(?:FROM|JOIN)\s+?)?`(?P<project>[-\w]+?)`?\.`?(?P<dataset>[\w]+?)`?\.`?(?P<table>[\w]+)`?"
+STANDARD_SQL_TABLE_PATTERN = r"(?:(?:FROM|JOIN)\s+?)?`(?P<project>[-\w]+?)`?\.`?(?P<dataset>[\w]+?)`?\.`?(?P<table>[\w]+)`?(?!\()\b"
 LEGACY_SQL_TABLE_PATTERN = r"(?:(?:FROM|JOIN)\s+?)?\[(?:(?P<project>[-\w]+?)(?:\:))?(?P<dataset>[-\w]+?)\.(?P<table>[-\w]+?)\]"
 
 logging.basicConfig()

--- a/tests/test_view_analyzer.py
+++ b/tests/test_view_analyzer.py
@@ -19,6 +19,7 @@ invalid_standard_table_references = [
     "project.`dataset.table`",
     "project.dataset.`table`",
     "project.dataset.table",
+    "`project`.dataset.function()",
 ]
 
 legacy_table_references = ["[project:dataset.table]", "[dataset.table]"]


### PR DESCRIPTION
## Summary
Update standard SQL table pattern to exclude UDFs (fixes https://github.com/servian/bigquery-view-analyzer/issues/10)

### Details
#### Analyzer Changes
- Add negative lookahead for left parenthesis at the end of a word boundary: `(?!\()\b`
  - [Current regex demo](https://regex101.com/r/DpKMmp/1)
  - [Updated regex demo](https://regex101.com/r/DpKMmp/2)

#### Test Changes
- Add UDF reference pattern to `invalid_standard_table_references`